### PR TITLE
Added the healthcheck name method.

### DIFF
--- a/nft/candid/nft.did
+++ b/nft/candid/nft.did
@@ -272,6 +272,9 @@ type AccountIdentifier = text;
 
  type erc721_token =
  service {
+   // HEALTH-CHECK //
+   name: () -> (text) query;
+   
    // BEGIN DIP-721 //
    balanceOfDip721: (user: principal) -> (nat64) query;
    ownerOfDip721: (token_id: nat64) -> (OwnerResult) query;

--- a/nft/src/service.rs
+++ b/nft/src/service.rs
@@ -11,6 +11,12 @@ use cap_sdk::IndefiniteEventBuilder;
 use cap_sdk::handshake;
 use cap_sdk::insert;
 
+/// HEALTH-CHECK ///
+#[query]
+fn name() -> String {
+  String::from("NFT Canister")
+}
+
 /// BEGIN DIP-721 ///
 #[query(name = "balanceOfDip721")]
 fn balance_of_dip721(user: Principal) -> u64 {


### PR DESCRIPTION
We use this method to make sure the canister works properly and the connection to the canister has been established.