### PR TITLE
chore: 🤖 add fleek testnet to dfx.json

### DIFF
--- a/dfx.json
+++ b/dfx.json
@@ -23,6 +23,10 @@
       "bind": "127.0.0.1:8000",
       "type": "ephemeral"
     },
+    "fleek-testnet": {
+      "bind": "34.216.56.80:8080",
+      "type": "ephemeral"
+    },
     "ic": {
       "bind": "ic0.app"
     }


### PR DESCRIPTION
## Why?

The dfx.json should have the fleek testnet, as it'll be required for automating deployments e.g. staging https://github.com/Psychedelic/nft-marketplace-fe/pull/71 which depends on this PR

## How?

- Add feek testnet network to dfx.json
