### PR TITLE
fix: 🐛 mint crowns dot env is missing

### DIFF
--- a/mocks/principals.js
+++ b/mocks/principals.js
@@ -1,4 +1,5 @@
 import { Secp256k1KeyIdentity } from "@dfinity/identity";
+import 'dotenv/config';
 
 export const userPrincipals = JSON.parse(process.env.USER_PRINCIPALS) || [];
 


### PR DESCRIPTION
## Why?

Missing dotenv config.

