### PR TITLE
refactor: set token ids to string for cap events

### DIFF
--- a/canister_ids.json
+++ b/canister_ids.json
@@ -1,4 +1,7 @@
 {
+  "cap": {
+    "ic": "lhtux-ciaaa-aaaag-qakpa-cai"
+  },
   "crowns": {
     "ic": "vlhm2-4iaaa-aaaam-qaatq-cai",
     "local": "rrkah-fqaaa-aaaaa-aaaaq-cai"

--- a/src/main.rs
+++ b/src/main.rs
@@ -580,7 +580,7 @@ fn approve(operator: Principal, token_identifier: TokenIdentifier) -> Result<Nat
                 ("operator".into(), DetailValue::from(operator)),
                 (
                     "token_identifier".into(),
-                    DetailValue::from(token_identifier),
+                    DetailValue::from(token_identifier.to_string()),
                 ),
             ],
         });
@@ -653,7 +653,7 @@ fn transfer(to: Principal, token_identifier: TokenIdentifier) -> Result<Nat, Nft
                 ("to".into(), DetailValue::from(to)),
                 (
                     "token_identifier".into(),
-                    DetailValue::from(token_identifier),
+                    DetailValue::from(token_identifier.to_string()),
                 ),
             ],
         });
@@ -694,7 +694,7 @@ fn transfer_from(
                 ("to".into(), DetailValue::from(to)),
                 (
                     "token_identifier".into(),
-                    DetailValue::from(token_identifier),
+                    DetailValue::from(token_identifier.to_string()),
                 ),
             ],
         });
@@ -744,7 +744,7 @@ fn mint(
                 ("to".into(), DetailValue::from(to)),
                 (
                     "token_identifier".into(),
-                    DetailValue::from(token_identifier),
+                    DetailValue::from(token_identifier.to_string()),
                 ),
             ],
         });


### PR DESCRIPTION
## Why?

cap handles Nat datatype as a nat8 slice, which is not easily readable/usable, so we use a string instead

## How?



## Tickets?

- [Ticket 1](the-ticket-url-here)
- [Ticket 2](the-ticket-url-here)
- [Ticket 3](the-ticket-url-here)

## Contribution checklist?

- [ ] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [ ] I have performed a self-review of my own code
- [ ] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
