### PR TITLE
chore: 🤖 mock canister ids from environment vars

### DIFF
--- a/mocks/mint-crowns.js
+++ b/mocks/mint-crowns.js
@@ -15,13 +15,14 @@ const amountE8sPerUser = 10_000_000_000;
 
 (async () => {
   const {
-    localCrownsCanisterId,
-    localWicpCanisterId,
     host,
     aggrCrownsJsonPath,
     chunkSize,
     chunkPromiseDelayMs,
   } = settings;
+
+  const localCrownsCanisterId = process.env.CROWNS_ID;
+  const localWicpCanisterId = process.env.WICP_ID;
 
   const { identity } = systemPrincipal;
 

--- a/mocks/settings.js
+++ b/mocks/settings.js
@@ -1,6 +1,4 @@
 const settings = {
-  "localCrownsCanisterId": "rkp4c-7iaaa-aaaaa-aaaca-cai",
-  "localWicpCanisterId": "qaa6y-5yaaa-aaaaa-aaafa-cai",
   "host": "http://127.0.0.1:8000",
   "aggrCrownsJsonPath": "../migrate/03_aggregate.json",
   "chunkSize": 100,


### PR DESCRIPTION
## Why?

The Canister Ids should be dynamically computed

⚠️ Requires https://github.com/Psychedelic/nft-marketplace-fe/pull/400 https://github.com/Psychedelic/nft-marketplace-fe/pull/399

## Demo?

<img width="808" alt="Screenshot 2022-06-21 at 17 03 55" src="https://user-images.githubusercontent.com/236752/174845825-acdd91ee-5430-4fc6-bd74-bab388bd1819.png">
