### PR TITLE
chore: 🤖 reduce chunk size to prevent 503

### DIFF
--- a/mocks/settings.js
+++ b/mocks/settings.js
@@ -1,8 +1,8 @@
 const settings = {
-  "host": "http://127.0.0.1:8000",
-  "aggrCrownsJsonPath": "./data.json",
-  "chunkSize": 100,
-  "chunkPromiseDelayMs": 1800,
+  host: 'http://127.0.0.1:8000',
+  aggrCrownsJsonPath: './data.json',
+  chunkSize: 50,
+  chunkPromiseDelayMs: 1800,
 };
 
 export default settings;


### PR DESCRIPTION
## Why?

On latest, a 503 is spit out when interacting with local replica, as such the number of items in a chunk needs to be reduced

## Demo?

Optionally, provide any screenshot, gif or small video.
