### PR TITLE
refactor: 💡 settings as json

### DIFF
--- a/mocks/mint-crowns.js
+++ b/mocks/mint-crowns.js
@@ -6,9 +6,13 @@ import fetch from 'isomorphic-fetch';
 import { readFileSync } from 'fs';
 import { Principal } from '@dfinity/principal';
 import { userPrincipals, systemPrincipal } from './principals.js';
-import settings from './settings.js';
 import { delay } from './utils.js';
 import 'dotenv/config';
+
+import { readFile } from 'fs/promises';
+const settings = JSON.parse(
+  await readFile(new URL('./settings.json', import.meta.url)),
+);
 
 // 100 WICP (10_000_000_000 / 10^8 )
 const amountE8sPerUser = 10_000_000_000;

--- a/mocks/settings.js
+++ b/mocks/settings.js
@@ -1,8 +1,0 @@
-const settings = {
-  host: 'http://127.0.0.1:8000',
-  aggrCrownsJsonPath: './data.json',
-  chunkSize: 50,
-  chunkPromiseDelayMs: 1800,
-};
-
-export default settings;

--- a/mocks/settings.json
+++ b/mocks/settings.json
@@ -1,0 +1,7 @@
+{
+  "host": "http://127.0.0.1:8000",
+  "aggrCrownsJsonPath": "./data.json",
+  "chunkSize": 50,
+  "chunkPromiseDelayMs": 1800
+}
+


### PR DESCRIPTION
## Why?

The settings should be json not a js object, for reusability.

